### PR TITLE
Fix for CursorWindow leaking native memory

### DIFF
--- a/jni/info_guardianproject_database_CursorWindow.cpp
+++ b/jni/info_guardianproject_database_CursorWindow.cpp
@@ -685,9 +685,9 @@ int register_android_database_CursorWindow(JNIEnv * env)
 {
     jclass clazz;
 
-    clazz = env->FindClass("android/database/CursorWindow");
+    clazz = env->FindClass("info/guardianproject/database/CursorWindow");
     if (clazz == NULL) {
-        LOGE("Can't find android/database/CursorWindow");
+        LOGE("Can't find info/guardianproject/database/CursorWindow");
         return -1;
     }
 

--- a/src/info/guardianproject/database/CursorWindow.java
+++ b/src/info/guardianproject/database/CursorWindow.java
@@ -534,6 +534,7 @@ public class CursorWindow extends android.database.CursorWindow implements Parce
 
     @Override
     protected void onAllReferencesReleased() {
-        close_native();        
+        close_native();
+		super.onAllReferencesReleased();
     }
 }


### PR DESCRIPTION
This change fixes the native memory leak when running cursors, there were 2 problems one is that the new CursorWindow was storing its Window \* in the superclasses nWindow not in the new subclasses nWindow. This would cause android.database.CursorWindow to create a window, then the pointer to it was overrwritten by the info.guardianproject.database.CursorWindow newly created window.

The 2nd issue is that the clean-up did not call through to cleanup the parent class.

I've tested this on a Samsung Galaxy S running 2.2, A Galaxy S2 running 2.3, and a Galaxy Tab running 3.1.

One remaining weirdness is that the window created by android.database.CursorWindow is never used, it'd be nice if there was someway to not have to create that.
