### PR TITLE
Add cursor changes to get the type of retrieved data (API 11)

### DIFF
--- a/jni/net_sqlcipher_CursorWindow.cpp
+++ b/jni/net_sqlcipher_CursorWindow.cpp
@@ -271,6 +271,22 @@ LOG_WINDOW("Checking if column is an integer for %d,%d from %p", row, column, wi
     return field.type == FIELD_TYPE_INTEGER;
 }
 
+static jint getType_native(JNIEnv* env, jobject object, jint row, jint column)
+{
+    int32_t err;
+    CursorWindow * window = GET_WINDOW(env, object);
+LOG_WINDOW("Getting type for %d,%d from %p", row, column, window);
+
+    field_slot_t field;
+    err = window->read_field_slot(row, column, &field);
+    if (err != 0) {
+        throwExceptionWithRowCol(env, row, column);
+        return NULL;
+    }
+
+    return field.type;
+}
+
 static jboolean isFloat_native(JNIEnv* env, jobject object, jint row, jint column)
 {
     int32_t err;
@@ -677,6 +693,7 @@ static JNINativeMethod sMethods[] =
     {"isString_native", "(II)Z", (void *)isString_native},
     {"isFloat_native", "(II)Z", (void *)isFloat_native},
     {"isInteger_native", "(II)Z", (void *)isInteger_native},
+    {"getType_native", "(II)I", (void *)getType_native},
 };
 
 int register_android_database_CursorWindow(JNIEnv * env)

--- a/src/net/sqlcipher/AbstractCursor.java
+++ b/src/net/sqlcipher/AbstractCursor.java
@@ -56,6 +56,10 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
     abstract public double getDouble(int column);
     abstract public boolean isNull(int column);
 
+    public int getType(int column) {
+        throw new UnsupportedOperationException();
+    }
+
     // TODO implement getBlob in all cursor types
     public byte[] getBlob(int column) {
         throw new UnsupportedOperationException("getBlob is not supported");
@@ -151,6 +155,8 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
                 result.getChars(0, result.length(), data, 0);
             }
             buffer.sizeCopied = result.length();
+        } else {
+            buffer.sizeCopied = 0;
         }
     }
     
@@ -205,7 +211,7 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
      * @param window
      */
     public void fillWindow(int position, android.database.CursorWindow window) {
-        if (position < 0 || position > getCount()) {
+        if (position < 0 || position >= getCount()) {
             return;
         }
         window.acquireReference();
@@ -523,6 +529,10 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
         }
     }
 
+    public Uri getNotificationUri() {
+        return mNotifyUri;
+    }
+
     public boolean getWantsAllOnMoveCalls() {
         return false;
     }
@@ -630,6 +640,12 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
     protected int mRowIdColumnIndex;
 
     protected int mPos;
+
+    /**
+     * If {@link #mRowIdColumnIndex} is not -1 this contains contains the value of
+     * the column at {@link #mRowIdColumnIndex} for the current row this cursor is
+     * pointing at.
+     */
     protected Long mCurrentRowID;
     protected ContentResolver mContentResolver;
     protected boolean mClosed = false;

--- a/src/net/sqlcipher/AbstractWindowedCursor.java
+++ b/src/net/sqlcipher/AbstractWindowedCursor.java
@@ -211,6 +211,12 @@ public abstract class AbstractWindowedCursor extends AbstractCursor
     }
 
     @Override
+    public int getType(int columnIndex) {
+        checkPosition();
+        return mWindow.getType(mPos, columnIndex);
+    }
+
+    @Override
     protected void checkPosition()
     {
         super.checkPosition();

--- a/src/net/sqlcipher/DatabaseUtils.java
+++ b/src/net/sqlcipher/DatabaseUtils.java
@@ -195,6 +195,37 @@ public class DatabaseUtils {
     }
 
     /**
+     * Returns data type of the given object's value.
+     *<p>
+     * Returned values are
+     * <ul>
+     *   <li>{@link Cursor#FIELD_TYPE_NULL}</li>
+     *   <li>{@link Cursor#FIELD_TYPE_INTEGER}</li>
+     *   <li>{@link Cursor#FIELD_TYPE_FLOAT}</li>
+     *   <li>{@link Cursor#FIELD_TYPE_STRING}</li>
+     *   <li>{@link Cursor#FIELD_TYPE_BLOB}</li>
+     *</ul>
+     *</p>
+     *
+     * @param obj the object whose value type is to be returned
+     * @return object value type
+     * @hide
+     */
+    public static int getTypeOfObject(Object obj) {
+        if (obj == null) {
+            return 0; /* Cursor.FIELD_TYPE_NULL */
+        } else if (obj instanceof byte[]) {
+            return 4; /* Cursor.FIELD_TYPE_BLOB */
+        } else if (obj instanceof Float || obj instanceof Double) {
+            return 2; /* Cursor.FIELD_TYPE_FLOAT */
+        } else if (obj instanceof Long || obj instanceof Integer) {
+            return 1; /* Cursor.FIELD_TYPE_INTEGER */
+        } else {
+            return 3; /* Cursor.FIELD_TYPE_STRING */
+        }
+    }
+
+    /**
      * Appends an SQL string to the given StringBuilder, including the opening
      * and closing single quotes. Any single quotes internal to sqlString will
      * be escaped.

--- a/src/net/sqlcipher/MatrixCursor.java
+++ b/src/net/sqlcipher/MatrixCursor.java
@@ -275,6 +275,11 @@ public class MatrixCursor extends AbstractCursor {
     }
 
     @Override
+    public int getType(int column) {
+        return DatabaseUtils.getTypeOfObject(get(column));
+    }
+
+    @Override
     public boolean isNull(int column) {
         return get(column) == null;
     }


### PR DESCRIPTION
These changes include some of the changes in the Android database cursor & other classes from API 11. I am adapting a sqlite plugin for Cordova/PhoneGap to use sqlcipher and would like to benefit from this functionality. I have a small change to sqlcipher-android-tests to test this functionality, which I will send in a pull request on that repository.
