### PR TITLE
Support Cursor.getType() for all Android API versions

### DIFF
--- a/src/net/sqlcipher/AbstractCursor.java
+++ b/src/net/sqlcipher/AbstractCursor.java
@@ -36,7 +36,7 @@ import android.util.Log;
  * This is an abstract cursor class that handles a lot of the common code
  * that all cursors need to deal with and is provided for convenience reasons.
  */
-public abstract class AbstractCursor implements android.database.CrossProcessCursor {
+public abstract class AbstractCursor implements android.database.CrossProcessCursor, net.sqlcipher.Cursor {
     private static final String TAG = "Cursor";
 
     DataSetObservable mDataSetObservable = new DataSetObservable();
@@ -56,9 +56,7 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
     abstract public double getDouble(int column);
     abstract public boolean isNull(int column);
 
-    public int getType(int column) {
-        throw new UnsupportedOperationException();
-    }
+    abstract public int getType(int column);
 
     // TODO implement getBlob in all cursor types
     public byte[] getBlob(int column) {

--- a/src/net/sqlcipher/CrossProcessCursorWrapper.java
+++ b/src/net/sqlcipher/CrossProcessCursorWrapper.java
@@ -1,9 +1,7 @@
 package net.sqlcipher;
 
-import android.database.Cursor;
 import android.database.CrossProcessCursor;
 import android.database.CursorWindow;
-import android.database.CursorWrapper;
 
 public class CrossProcessCursorWrapper extends CursorWrapper implements CrossProcessCursor {
 

--- a/src/net/sqlcipher/Cursor.java
+++ b/src/net/sqlcipher/Cursor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.sqlcipher;
+
+/**
+ * Extension of android.database.Cursor to support getType() for API < 11.
+ */
+public interface Cursor extends android.database.Cursor {
+    /*
+     * Values returned by {@link #getType(int)}.
+     * These should be consistent with the corresponding types defined in CursorWindow.h
+     */
+    /** Value returned by {@link #getType(int)} if the specified column is null */
+    static final int FIELD_TYPE_NULL = 0;
+
+    /** Value returned by {@link #getType(int)} if the specified  column type is integer */
+    static final int FIELD_TYPE_INTEGER = 1;
+
+    /** Value returned by {@link #getType(int)} if the specified column type is float */
+    static final int FIELD_TYPE_FLOAT = 2;
+
+    /** Value returned by {@link #getType(int)} if the specified column type is string */
+    static final int FIELD_TYPE_STRING = 3;
+
+    /** Value returned by {@link #getType(int)} if the specified column type is blob */
+    static final int FIELD_TYPE_BLOB = 4;
+
+    /**
+     * Returns data type of the given column's value.
+     * The preferred type of the column is returned but the data may be converted to other types
+     * as documented in the get-type methods such as {@link #getInt(int)}, {@link #getFloat(int)}
+     * etc.
+     *<p>
+     * Returned column types are
+     * <ul>
+     *   <li>{@link #FIELD_TYPE_NULL}</li>
+     *   <li>{@link #FIELD_TYPE_INTEGER}</li>
+     *   <li>{@link #FIELD_TYPE_FLOAT}</li>
+     *   <li>{@link #FIELD_TYPE_STRING}</li>
+     *   <li>{@link #FIELD_TYPE_BLOB}</li>
+     *</ul>
+     *</p>
+     *
+     * @param columnIndex the zero-based index of the target column.
+     * @return column value type
+     */
+    int getType(int columnIndex);
+}

--- a/src/net/sqlcipher/CursorWindow.java
+++ b/src/net/sqlcipher/CursorWindow.java
@@ -17,7 +17,6 @@
 package net.sqlcipher;
 
 import android.database.CharArrayBuffer;
-import android.database.Cursor;
 
 import android.content.res.Resources;
 import android.database.sqlite.SQLiteClosable;

--- a/src/net/sqlcipher/CursorWrapper.java
+++ b/src/net/sqlcipher/CursorWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.sqlcipher;
+
+/**
+ * Extension of android.database.CursorWrapper to support getType() for API < 11.
+ */
+public class CursorWrapper extends android.database.CursorWrapper implements Cursor {
+
+    private final Cursor mCursor;
+
+    public CursorWrapper(Cursor cursor) {
+        super(cursor);
+        mCursor = cursor;
+    }
+
+    public int getType(int columnIndex) {
+        return mCursor.getType(columnIndex);
+    }
+}
+

--- a/src/net/sqlcipher/database/SQLiteCursorDriver.java
+++ b/src/net/sqlcipher/database/SQLiteCursorDriver.java
@@ -31,7 +31,7 @@ public interface SQLiteCursorDriver {
      *         null if standard SQLiteCursors should be returned.
      * @return a Cursor over the result set
      */
-    android.database.Cursor query(CursorFactory factory, String[] bindArgs);
+    Cursor query(CursorFactory factory, String[] bindArgs);
 
     /**
      * Called by a SQLiteCursor when it is released.

--- a/src/net/sqlcipher/database/SQLiteDatabase.java
+++ b/src/net/sqlcipher/database/SQLiteDatabase.java
@@ -16,6 +16,7 @@
 
 package net.sqlcipher.database;
 
+import net.sqlcipher.Cursor;
 import net.sqlcipher.CrossProcessCursorWrapper;
 import net.sqlcipher.DatabaseUtils;
 import net.sqlcipher.SQLException;
@@ -43,7 +44,7 @@ import java.util.zip.ZipInputStream;
 import android.content.ContentValues;
 
 import android.content.Context;
-import android.database.Cursor;
+
 import android.os.Debug;
 import android.os.SystemClock;
 import android.text.TextUtils;

--- a/src/net/sqlcipher/database/SQLiteDirectCursorDriver.java
+++ b/src/net/sqlcipher/database/SQLiteDirectCursorDriver.java
@@ -16,8 +16,8 @@
 
 package net.sqlcipher.database;
 
+import net.sqlcipher.Cursor;
 import net.sqlcipher.database.SQLiteDatabase.CursorFactory;
-import android.database.Cursor;
 
 /**
  * A cursor driver that uses the given query directly.
@@ -27,7 +27,7 @@ import android.database.Cursor;
 public class SQLiteDirectCursorDriver implements SQLiteCursorDriver {
     private String mEditTable; 
     private SQLiteDatabase mDatabase;
-    private android.database.Cursor mCursor;
+    private Cursor mCursor;
     private String mSql;
     private SQLiteQuery mQuery;
 
@@ -37,7 +37,7 @@ public class SQLiteDirectCursorDriver implements SQLiteCursorDriver {
         mSql = sql;
     }
 
-    public android.database.Cursor query(CursorFactory factory, String[] selectionArgs) {
+    public Cursor query(CursorFactory factory, String[] selectionArgs) {
         // Compile the query
         SQLiteQuery query = new SQLiteQuery(mDatabase, mSql, 0, selectionArgs);
 
@@ -76,11 +76,13 @@ public class SQLiteDirectCursorDriver implements SQLiteCursorDriver {
         }
     }
 
+    @Override
     public void cursorDeactivated() {
         // Do nothing
     }
 
-    public void cursorRequeried(Cursor cursor) {
+    @Override
+    public void cursorRequeried(android.database.Cursor cursor) {
         // Do nothing
     }
 

--- a/src/net/sqlcipher/database/SQLiteQueryBuilder.java
+++ b/src/net/sqlcipher/database/SQLiteQueryBuilder.java
@@ -15,6 +15,7 @@
  */
 
 package net.sqlcipher.database;
+
 import net.sqlcipher.*;
 
 import android.provider.BaseColumns;
@@ -273,7 +274,7 @@ public class SQLiteQueryBuilder
      * @see android.content.ContentResolver#query(android.net.Uri, String[],
      *      String, String[], String)
      */
-    public android.database.Cursor query(SQLiteDatabase db, String[] projectionIn,
+    public Cursor query(SQLiteDatabase db, String[] projectionIn,
             String selection, String[] selectionArgs, String groupBy,
             String having, String sortOrder) {
         return query(db, projectionIn, selection, selectionArgs, groupBy, having, sortOrder,
@@ -312,7 +313,7 @@ public class SQLiteQueryBuilder
      * @see android.content.ContentResolver#query(android.net.Uri, String[],
      *      String, String[], String)
      */
-    public android.database.Cursor query(SQLiteDatabase db, String[] projectionIn,
+    public Cursor query(SQLiteDatabase db, String[] projectionIn,
             String selection, String[] selectionArgs, String groupBy,
             String having, String sortOrder, String limit) {
         if (mTables == null) {

--- a/src/net/sqlcipher/database/SqliteWrapper.java
+++ b/src/net/sqlcipher/database/SqliteWrapper.java
@@ -20,8 +20,9 @@ package net.sqlcipher.database;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
-import android.database.Cursor;
+
 import net.sqlcipher.*;
+
 import android.net.Uri;
 import android.util.Log;
 import android.widget.Toast;
@@ -64,7 +65,7 @@ public final class SqliteWrapper {
         }
     }
 
-    public static boolean requery(Context context, Cursor cursor) {
+    public static boolean requery(Context context, android.database.Cursor cursor) {
         try {
             return cursor.requery();
         } catch (SQLiteException e) {


### PR DESCRIPTION
This change adds 2 new classes: net.sqlcipher.Cursor & net.sqlcipher.CursorWrapper, that derive from the versions from android.database, and other changes to support Cursor.getType() for all versions of the Android API. This change was tested using the new CursorAccessTest which will be submitted in another pull request. This change should be the final fix for an issue with using https://github.com/brodyspark/PhoneGap-SQLitePlugin-Android with SQLCipher.
