### PR TITLE
Fix build on android ndk r9, merge libsqlcipher_android.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SECOND_LATEST_TAG := $(shell git tag | sort -r | head -2 | tail -1)
 RELEASE_DIR := "SQLCipher for Android ${LATEST_TAG}"
 CHANGE_LOG_HEADER := "Changes included in the ${LATEST_TAG} release of SQLCipher for Android:"
 README := ${RELEASE_DIR}/README
+MAKE_JOBS ?= 16
 
 init:
 	git submodule update --init
@@ -20,13 +21,11 @@ all: build-external build-jni build-java copy-libs
 
 build-external:
 	cd ${EXTERNAL_DIR} && \
-	make -f Android.mk build-local-hack && \
-	ndk-build && \
-	make -f Android.mk copy-libs-hack
+	make -f Android.mk build-local-hack
 
 build-jni:
-	cd ${JNI_DIR} && \
-	ndk-build
+	cd ${CURDIR} && \
+	ndk-build -j${MAKE_JOBS}
 
 build-java:
 	ant release && \
@@ -48,33 +47,12 @@ release:
 clean:
 	-rm SQLCipher\ for\ Android\*.zip
 	ant clean
-	cd ${EXTERNAL_DIR} && ndk-build clean
+	cd ${CURDIR} && ndk-build clean
 	-cd ${SQLCIPHER_DIR} && make clean
-	cd ${JNI_DIR} && ndk-build clean
-	-rm ${LIBRARY_ROOT}/armeabi/libsqlcipher_android.so
-	-rm ${LIBRARY_ROOT}/armeabi/libdatabase_sqlcipher.so
-	-rm ${LIBRARY_ROOT}/armeabi/libstlport_shared.so
 	-rm ${LIBRARY_ROOT}/sqlcipher.jar
-	-rm ${LIBRARY_ROOT}/x86/libsqlcipher_android.so
-	-rm ${LIBRARY_ROOT}/x86/libdatabase_sqlcipher.so
-	-rm ${LIBRARY_ROOT}/x86/libstlport_shared.so
 
 copy-libs:
-	mkdir -p ${LIBRARY_ROOT}/armeabi
-	cp ${EXTERNAL_DIR}/libs/armeabi/libsqlcipher_android.so \
-		 ${LIBRARY_ROOT}/armeabi  && \
-	cp ${JNI_DIR}/libs/armeabi/libdatabase_sqlcipher.so \
-		${LIBRARY_ROOT}/armeabi && \
-	cp ${CURDIR}/bin/classes/sqlcipher.jar ${LIBRARY_ROOT} && \
-	cp ${EXTERNAL_DIR}/libs/armeabi/libstlport_shared.so \
-		 ${LIBRARY_ROOT}/armeabi
-	mkdir -p ${LIBRARY_ROOT}/x86
-	cp ${EXTERNAL_DIR}/libs/x86/libsqlcipher_android.so \
-		 ${LIBRARY_ROOT}/x86  && \
-	cp ${JNI_DIR}/libs/x86/libdatabase_sqlcipher.so \
-		${LIBRARY_ROOT}/x86 && \
-	cp ${EXTERNAL_DIR}/libs/x86/libstlport_shared.so \
-		 ${LIBRARY_ROOT}/x86
+	cp ${CURDIR}/bin/classes/sqlcipher.jar ${LIBRARY_ROOT}
 
 copy-libs-dist:
 	cp ${LIBRARY_ROOT}/*.jar dist/SQLCipherForAndroid-SDK/libs/ && \

--- a/external/VisibilityIcu.h
+++ b/external/VisibilityIcu.h
@@ -1,0 +1,10 @@
+/* Dirty hack changing ICU visibility to hidden */
+
+#ifndef _VISIBILITY_ICU_H
+#define _VISIBILITY_ICU_H
+
+#include <unicode/platform.h>
+#undef U_EXPORT
+#define U_EXPORT
+
+#endif

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,6 +1,6 @@
 LOCAL_PATH:= $(call my-dir)
 
-EXTERNAL_PATH := ../external
+EXTERNAL_PATH := $(LOCAL_PATH)/../external
 
 LOCAL_CFLAGS += -DPACKED="__attribute__ ((packed))"
 
@@ -42,24 +42,18 @@ LOCAL_C_INCLUDES += \
 	$(EXTERNAL_PATH)/platform-frameworks-base/include \
 	$(EXTERNAL_PATH)/icu4c/common \
 
-LOCAL_SHARED_LIBRARIES := \
-	libcrypto \
-	libssl \
-	libsqlcipher \
-	libsqlite3_android
+#LOCAL_SHARED_LIBRARIES := libsqlcipher_android
+LOCAL_STATIC_LIBRARIES := libsqlcipher_android libicuuc
 
 LOCAL_CFLAGS += -U__APPLE__
-LOCAL_LDFLAGS += -L../external/android-libs/$(TARGET_ARCH_ABI) -L../external/libs/$(TARGET_ARCH_ABI)/
+LOCAL_LDFLAGS += -L$(EXTERNAL_PATH)/android-libs/$(TARGET_ARCH_ABI) -L$(EXTERNAL_PATH)/libs/$(TARGET_ARCH_ABI)/
 
 # libs from the NDK
 LOCAL_LDLIBS += -ldl -llog
 # libnativehelper and libandroid_runtime are included with Android but not the NDK
-LOCAL_LDLIBS += -lnativehelper -landroid_runtime -lutils -lbinder
-# these are build in the ../external section
+LOCAL_LDLIBS += -lnativehelper -landroid_runtime -lutils -lbinder -lcrypto
 
-LOCAL_LDLIBS  += -lsqlcipher_android
-LOCAL_LDFLAGS += -L../obj/local/$(TARGET_ARCH_ABI)
-LOCAL_LDLIBS  += -licui18n -licuuc
+# these are build in the ../external section
 
 ifeq ($(WITH_MALLOC_LEAK_CHECK),true)
 	LOCAL_CFLAGS += -DMALLOC_LEAK_CHECK
@@ -69,4 +63,5 @@ LOCAL_MODULE:= libdatabase_sqlcipher
 
 include $(BUILD_SHARED_LIBRARY)
 
-include $(call all-makefiles-under,$(LOCAL_PATH))
+$(call import-module,external)
+

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,6 +1,8 @@
 APP_PROJECT_PATH := $(shell pwd)
 APP_ABI := armeabi x86
-APP_BUILD_SCRIPT := $(APP_PROJECT_PATH)/Android.mk
+#APP_PLATFORM := android-8
+NDK_MODULE_PATH=$(APP_PROJECT_PATH)
 # fixes this error when building external/android-sqlite/android/sqlite3_android.cpp
 #   icu4c/common/unicode/std_string.h:39:18: error: string: No such file or directory
 APP_STL := stlport_shared
+

--- a/src/net/sqlcipher/database/SQLiteDatabase.java
+++ b/src/net/sqlcipher/database/SQLiteDatabase.java
@@ -140,7 +140,6 @@ public class SQLiteDatabase extends SQLiteClosable {
     public static void loadLibs (Context context, File workingDir)
     {
         System.loadLibrary("stlport_shared");
-        System.loadLibrary("sqlcipher_android");
         System.loadLibrary("database_sqlcipher");
 
         boolean systemICUFileExists = new File("/system/usr/icu/icudt46l.dat").exists();


### PR DESCRIPTION
Fix build on android ndk r9
Merge libsqlcipher_android.so into libdatabase_sqlcipher.so
Hide unnecesary ICU / sqlite3 symbols with -fvisibility=hidden
