### PR TITLE
Fix build when using Android NDK >= r9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ all: build-external build-jni build-java copy-libs
 build-external:
 	cd ${EXTERNAL_DIR} && \
 	make -f Android.mk build-local-hack && \
-	ndk-build && \
+	ndk-build NDK_LIBS_OUT=$(EXTERNAL_DIR)/libs && \
 	make -f Android.mk copy-libs-hack
 
 build-jni:
 	cd ${JNI_DIR} && \
-	ndk-build
+	ndk-build NDK_LIBS_OUT=$(JNI_DIR)/libs
 
 build-java:
 	ant release && \
@@ -51,9 +51,9 @@ release:
 clean:
 	-rm SQLCipher\ for\ Android\*.zip
 	-ant clean
-	-cd ${EXTERNAL_DIR} && ndk-build clean
+	-cd ${EXTERNAL_DIR} && ndk-build clean NDK_LIBS_OUT=$(EXTERNAL_DIR)/libs
 	-cd ${SQLCIPHER_DIR} && make clean
-	-cd ${JNI_DIR} && ndk-build clean
+	-cd ${JNI_DIR} && ndk-build clean NDK_LIBS_OUT=$(JNI_DIR)/libs
 	-rm ${LIBRARY_ROOT}/armeabi/libsqlcipher_android.so
 	-rm ${LIBRARY_ROOT}/armeabi/libdatabase_sqlcipher.so
 	-rm ${LIBRARY_ROOT}/armeabi/libstlport_shared.so


### PR DESCRIPTION
Android NDK tools places all generated libraries under `$PROJECT/libs` directory.
Since android-ndk-r9, at least on Ubuntu, NDK Tools places generated `*.so` under `libs/` while we expect them under `$(EXTERNAL_DIR)/libs` and `$(JNI_DIR)/libs`.
The solution is to specify libraries directory using `NDK_LIBS_OUT`.

NDK docs:
android-ndk-r9b/docs/OVERVIEW.html III.6/ Specifying custom output directories

Reports about this bug:
https://groups.google.com/d/msg/sqlcipher/cbt5ZOVMgEk/kiiWi4e8fIoJ
https://groups.google.com/d/msg/sqlcipher/WqDDsH4nUtE/EYUcSJ8G2L0J
