### PR TITLE
Show how to configure proguard for SQLCipher

### DIFF
--- a/proguard-project.txt
+++ b/proguard-project.txt
@@ -18,3 +18,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# SQLCipher, keep JNI integration methods
+-keepclassmembers class net.sqlcipher.** {
+      native <methods>;
+}


### PR DESCRIPTION
This helps folks that proguard their app, as it's often customary to have the necessary rules
in the library's proguard-project.txt so they can be copied form there (instead of guesstimated).
