### PR TITLE
Fixed ICU extraction for multiple processes.

### DIFF
--- a/src/net/sqlcipher/database/SQLiteDatabase.java
+++ b/src/net/sqlcipher/database/SQLiteDatabase.java
@@ -158,7 +158,8 @@ public class SQLiteDatabase extends SQLiteClosable {
             File icuDataFile = new File(icuDir, "icudt46l.dat");            
             if (!icuLockAcquire(icuDir, 7000)){
                 Log.w(TAG, "Could not acquire ICU extraction lock");
-                return;
+                // Continue anyway, there may be a problem with file locking.
+                // 7 seconds is long enough.
             }
             
             if (icuDataFile.exists()){


### PR DESCRIPTION
Fixes segfault in the following scenario: two Android processes launched
during application start tried to extract ICU file at the same time
overwriting destination file by each other. This results in segmentation
fault while loading ICU in native library.

The segmentation fault ocurred in checkDataItem function at external/icu4c/common/udata.cpp. In particular on line with "pHeader->dataHeader.magic1==0xda".

How to reproduce a problem:
* Create 2 independent processes in android application, e.g., two services running in different process.
* Start both services on application start.
* Open (different) SQLite databases in both processes.
* Tested on Android KitKat (API 19), Motorola Moto G.

This proposed patch fixes the problem by: 
1) using file locking so only one process extracts ZIP archive and writes the destination in time; 
2) extracting to a temporary file, then renaming it to the destination file name;
3) forcing flushing/syncing file to file system using channels and sync so native library can process it right after the extraction routine finishes.
