### PR TITLE
Fix default target to generate build.xml on Android SDK 24 (Android 5.1)

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-7
+target=android-19


### PR DESCRIPTION
Change default target from `android-7` to `android-19`  in `project.properties`.

My first attempt to build this project using the new Android SDK failed because `build.xml` had not been generated. My first attempt to run `android update project -p .` to generate `build.xml` failed with the following message:

```shell
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
```

When I changed default target in project.properties from `android-7` to `android-19` (by running `android update project -p . -t android-19` as recommended in a comment in #153) then `build.xml` is generated and I can build.