### PR TITLE
Workaround bug in NDK gold linker

### DIFF
--- a/external/Android.mk
+++ b/external/Android.mk
@@ -95,6 +95,7 @@ LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/platform-system-core/include \
 	$(LOCAL_PATH)/platform-frameworks-base/include
 
+LOCAL_LDFLAGS += -fuse-ld=bfd
 LOCAL_LDFLAGS += -L${LOCAL_PATH}/android-libs/$(TARGET_ARCH_ABI)/ -L$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/
 LOCAL_LDLIBS := -llog -lutils -lcutils
 LOCAL_MODULE := libsqlcipher_android

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -57,6 +57,7 @@ LOCAL_LDLIBS += -ldl -llog
 LOCAL_LDLIBS += -lnativehelper -landroid_runtime -lutils -lbinder
 # these are build in the ../external section
 
+LOCAL_LDFLAGS += -fuse-ld=bfd
 LOCAL_LDLIBS  += -lsqlcipher_android
 LOCAL_LDFLAGS += -L../obj/local/$(TARGET_ARCH_ABI)
 LOCAL_LDLIBS  += -licui18n -licuuc


### PR DESCRIPTION
Pointed out by @lkjh654 in pull request #151, see also: https://code.google.com/p/android/issues/detail?id=109071

I encountered this problem when attempting to run `sqlcipher-android-tests` on my Motorola Moto G which seems to be normal `arm` 32-bit, which is solved by these changes.