### PR TITLE
Fix small memory leak and mark more exceptions

### DIFF
--- a/src/net/sqlcipher/database/SQLiteDatabase.java
+++ b/src/net/sqlcipher/database/SQLiteDatabase.java
@@ -558,6 +558,8 @@ public class SQLiteDatabase extends SQLiteClosable {
      *     db.endTransaction();
      *   }
      * </pre>
+     *
+     * @throws IllegalStateException if the database is not open
      */
     public void beginTransaction() {
         beginTransactionWithListener(null /* transactionStatusCallback */);
@@ -583,6 +585,8 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @param transactionListener listener that should be notified when the transaction begins,
      * commits, or is rolled back, either explicitly or by a call to
      * {@link #yieldIfContendedSafely}.
+     *
+     * @throws IllegalStateException if the database is not open
      */
     public void beginTransactionWithListener(SQLiteTransactionListener transactionListener) {
         lockForced();
@@ -631,6 +635,8 @@ public class SQLiteDatabase extends SQLiteClosable {
     /**
      * End a transaction. See beginTransaction for notes about how to use this and when transactions
      * are committed and rolled back.
+     *
+     * @throws IllegalStateException if the database is not open or is not locked by the current thread
      */
     public void endTransaction() {
         if (!isOpen()) {
@@ -692,8 +698,8 @@ public class SQLiteDatabase extends SQLiteClosable {
      * situation too. If any errors are encountered between this and endTransaction the transaction
      * will still be committed.
      *
-     * @throws IllegalStateException if the current thread is not in a transaction or the
-     * transaction is already marked as successful.
+     * @throws IllegalStateException if the database is not open, the current thread is not in a transaction,
+     * or the transaction is already marked as successful.
      */
     public void setTransactionSuccessful() {
         if (!isOpen()) {
@@ -731,7 +737,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * including after the call is made but before the result has
      * been acted upon.
      *
-     * @return true, if the database is locked by another thread
+     * @return true if the transaction was yielded, false if queue was empty or database was not open
      */
     public boolean isDbLockedByOtherThreads() {
         return !mLock.isHeldByCurrentThread() && mLock.isLocked();
@@ -741,12 +747,17 @@ public class SQLiteDatabase extends SQLiteClosable {
      * Temporarily end the transaction to let other threads run. The transaction is assumed to be
      * successful so far. Do not call setTransactionSuccessful before calling this. When this
      * returns a new transaction will have been created but not marked as successful.
+     *
      * @return true if the transaction was yielded
+     *
      * @deprecated if the db is locked more than once (becuase of nested transactions) then the lock
      *   will not be yielded. Use yieldIfContendedSafely instead.
      */
     @Deprecated
     public boolean yieldIfContended() {
+        /* safeguard: */
+        if (!isOpen()) return false;
+
         return yieldIfContendedHelper(false /* do not check yielding */,
                                       -1 /* sleepAfterYieldDelay */);
     }
@@ -757,9 +768,13 @@ public class SQLiteDatabase extends SQLiteClosable {
      * returns a new transaction will have been created but not marked as successful. This assumes
      * that there are no nested transactions (beginTransaction has only been called once) and will
      * throw an exception if that is not the case.
-     * @return true if the transaction was yielded
+     *
+     * @return true if the transaction was yielded, false if queue was empty or database was not open
      */
     public boolean yieldIfContendedSafely() {
+        /* safeguard: */
+        if (!isOpen()) return false;
+
         return yieldIfContendedHelper(true /* check yielding */, -1 /* sleepAfterYieldDelay*/);
     }
 
@@ -769,12 +784,20 @@ public class SQLiteDatabase extends SQLiteClosable {
      * returns a new transaction will have been created but not marked as successful. This assumes
      * that there are no nested transactions (beginTransaction has only been called once) and will
      * throw an exception if that is not the case.
+     *
      * @param sleepAfterYieldDelay if > 0, sleep this long before starting a new transaction if
      *   the lock was actually yielded. This will allow other background threads to make some
      *   more progress than they would if we started the transaction immediately.
-     * @return true if the transaction was yielded
+     *
+     * @return true if the transaction was yielded, false if queue was empty or database was not open
+     *
+     * @throws IllegalStateException if the database is locked more than once by the current thread
+     * @throws InterruptedException if the thread was interrupted while sleeping
      */
     public boolean yieldIfContendedSafely(long sleepAfterYieldDelay) {
+        /* safeguard: */
+        if (!isOpen()) return false;
+
         return yieldIfContendedHelper(true /* check yielding */, sleepAfterYieldDelay);
     }
 
@@ -897,6 +920,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @return the newly opened database
      *
      * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
      */
     public static SQLiteDatabase openDatabase(String path, String password, CursorFactory factory, int flags) {
       return openDatabase(path, password.toCharArray(), factory, flags, null);
@@ -906,7 +930,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * Open the database according to the flags {@link #OPEN_READWRITE}
      * {@link #OPEN_READONLY} {@link #CREATE_IF_NECESSARY} and/or {@link #NO_LOCALIZED_COLLATORS}.
      *
-     * <p>Sets the locale of the database to the  the system's current locale.
+     * <p>Sets the locale of the database to the system's current locale.
      * Call {@link #setLocale} if you would like something else.</p>
      *
      * @param path to database file to open and/or create
@@ -918,6 +942,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @return the newly opened database
      *
      * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
      */
     public static SQLiteDatabase openDatabase(String path, char[] password, CursorFactory factory, int flags) {
       return openDatabase(path, password, factory, flags, null);
@@ -941,6 +966,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @return the newly opened database
      *
      * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
      */
     public static SQLiteDatabase openDatabase(String path, String password, CursorFactory factory, int flags, SQLiteDatabaseHook hook) {
       return openDatabase(path, password.toCharArray(), factory, flags, hook);
@@ -964,6 +990,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @return the newly opened database
      *
      * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
      */
     public static SQLiteDatabase openDatabase(String path, char[] password, CursorFactory factory, int flags, SQLiteDatabaseHook hook) {
         SQLiteDatabase sqliteDatabase = null;
@@ -995,33 +1022,44 @@ public class SQLiteDatabase extends SQLiteClosable {
         return sqliteDatabase;
     }
 
+    /**
+     * Equivalent to openDatabase(file.getPath(), password, factory, CREATE_IF_NECESSARY, databaseHook).
+     */
     public static SQLiteDatabase openOrCreateDatabase(File file, String password, CursorFactory factory, SQLiteDatabaseHook databaseHook){
         return openOrCreateDatabase(file.getPath(), password, factory, databaseHook);
     }
 
+    /**
+     * Equivalent to openDatabase(path, password, factory, CREATE_IF_NECESSARY, databaseHook).
+     */
     public static SQLiteDatabase openOrCreateDatabase(String path, String password, CursorFactory factory, SQLiteDatabaseHook databaseHook) {
         return openDatabase(path, password, factory, CREATE_IF_NECESSARY, databaseHook);
     }
 
+    /**
+     * Equivalent to openDatabase(path, password, factory, CREATE_IF_NECESSARY, databaseHook).
+     */
     public static SQLiteDatabase openOrCreateDatabase(String path, char[] password, CursorFactory factory, SQLiteDatabaseHook databaseHook) {
       return openDatabase(path, password, factory, CREATE_IF_NECESSARY, databaseHook);
     }
 
     /**
-     * Equivalent to openDatabase(file.getPath(), factory, CREATE_IF_NECESSARY).
+     * Equivalent to openDatabase(file.getPath(), password, factory, CREATE_IF_NECESSARY).
      */
     public static SQLiteDatabase openOrCreateDatabase(File file, String password, CursorFactory factory) {
         return openOrCreateDatabase(file.getPath(), password, factory, null);
     }
 
     /**
-     * Equivalent to openDatabase(path, factory, CREATE_IF_NECESSARY).
+     * Equivalent to openDatabase(path, password, factory, CREATE_IF_NECESSARY).
      */
-
     public static SQLiteDatabase openOrCreateDatabase(String path, String password, CursorFactory factory) {
       return openDatabase(path, password.toCharArray(), factory, CREATE_IF_NECESSARY, null);
     }
 
+    /**
+     * Equivalent to openDatabase(path, password, factory, CREATE_IF_NECESSARY).
+     */
     public static SQLiteDatabase openOrCreateDatabase(String path, char[] password, CursorFactory factory) {
       return openDatabase(path, password, factory, CREATE_IF_NECESSARY, null);
     }
@@ -1035,13 +1073,32 @@ public class SQLiteDatabase extends SQLiteClosable {
      *
      * @param factory an optional factory class that is called to instantiate a
      *            cursor when query is called
+     * @param password to use to open and/or create database file
+     *
      * @return a SQLiteDatabase object, or null if the database can't be created
+     *
+     * @throws SQLiteException if the database cannot be opened 
      */
     public static SQLiteDatabase create(CursorFactory factory, String password) {
         // This is a magic string with special meaning for SQLite.
       return openDatabase(":memory:", password.toCharArray(), factory, CREATE_IF_NECESSARY);
     }
 
+    /**
+     * Create a memory backed SQLite database.  Its contents will be destroyed
+     * when the database is closed.
+     *
+     * <p>Sets the locale of the database to the  the system's current locale.
+     * Call {@link #setLocale} if you would like something else.</p>
+     *
+     * @param factory an optional factory class that is called to instantiate a
+     *            cursor when query is called
+     * @param password to use to open and/or create database file (char array)
+     *
+     * @return a SQLiteDatabase object, or null if the database can't be created
+     *
+     * @throws SQLiteException if the database cannot be opened 
+     */
     public static SQLiteDatabase create(CursorFactory factory, char[] password) {
         return openDatabase(":memory:", password, factory, CREATE_IF_NECESSARY);
     }
@@ -1094,6 +1151,8 @@ public class SQLiteDatabase extends SQLiteClosable {
      * Gets the database version.
      *
      * @return the database version
+     *
+     * @throws IllegalStateException if the database is not open
      */
     public int getVersion() {
         SQLiteStatement prog = null;
@@ -1115,6 +1174,9 @@ public class SQLiteDatabase extends SQLiteClosable {
      * Sets the database version.
      *
      * @param version the new database version
+     *
+     * @throws SQLiteException if there is an issue executing the sql internally
+     * @throws IllegalStateException if the database is not open
      */
     public void setVersion(int version) {
         execSQL("PRAGMA user_version = " + version);
@@ -1315,8 +1377,12 @@ public class SQLiteDatabase extends SQLiteClosable {
      *
      * @param sql The raw SQL statement, may contain ? for unknown values to be
      *            bound later.
+     *
      * @return A pre-compiled {@link SQLiteStatement} object. Note that
      * {@link SQLiteStatement}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public SQLiteStatement compileStatement(String sql) throws SQLException {
         lock();
@@ -1357,8 +1423,13 @@ public class SQLiteDatabase extends SQLiteClosable {
      *            default sort order, which may be unordered.
      * @param limit Limits the number of rows returned by the query,
      *            formatted as LIMIT clause. Passing null denotes no LIMIT clause.
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLiteException if there is an issue executing the sql or the SQL string is invalid
+     * @throws IllegalStateException if the database is not open
+     *
      * @see Cursor
      */
     public Cursor query(boolean distinct, String table, String[] columns,
@@ -1396,8 +1467,10 @@ public class SQLiteDatabase extends SQLiteClosable {
      *            default sort order, which may be unordered.
      * @param limit Limits the number of rows returned by the query,
      *            formatted as LIMIT clause. Passing null denotes no LIMIT clause.
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
      * @see Cursor
      */
     public Cursor queryWithFactory(CursorFactory cursorFactory,
@@ -1438,8 +1511,13 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @param orderBy How to order the rows, formatted as an SQL ORDER BY clause
      *            (excluding the ORDER BY itself). Passing null will use the
      *            default sort order, which may be unordered.
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLiteException if there is an issue executing the sql or the SQL string is invalid
+     * @throws IllegalStateException if the database is not open
+     *
      * @see Cursor
      */
     public Cursor query(String table, String[] columns, String selection,
@@ -1476,8 +1554,13 @@ public class SQLiteDatabase extends SQLiteClosable {
      *            default sort order, which may be unordered.
      * @param limit Limits the number of rows returned by the query,
      *            formatted as LIMIT clause. Passing null denotes no LIMIT clause.
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLiteException if there is an issue executing the sql or the SQL string is invalid
+     * @throws IllegalStateException if the database is not open
+     *
      * @see Cursor
      */
     public Cursor query(String table, String[] columns, String selection,
@@ -1495,8 +1578,12 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @param selectionArgs You may include ?s in where clause in the query,
      *     which will be replaced by the values from selectionArgs. The
      *     values will be bound as Strings.
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLiteException if there is an issue executing the sql or the SQL string is invalid
+     * @throws IllegalStateException if the database is not open
      */
     public Cursor rawQuery(String sql, String[] selectionArgs) {
         return rawQueryWithFactory(null, sql, selectionArgs, null);
@@ -1511,8 +1598,12 @@ public class SQLiteDatabase extends SQLiteClosable {
      *     which will be replaced by the values from selectionArgs. The
      *     values will be bound as Strings.
      * @param editTable the name of the first table, which is editable
+     *
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
+     *
+     * @throws SQLiteException if there is an issue executing the sql or the SQL string is invalid
+     * @throws IllegalStateException if the database is not open
      */
     public Cursor rawQueryWithFactory(
                                       CursorFactory cursorFactory, String sql, String[] selectionArgs,
@@ -1668,10 +1759,14 @@ public class SQLiteDatabase extends SQLiteClosable {
      *            row. The keys should be the column names and the values the
      *            column values
      * @param conflictAlgorithm for insert conflict resolver
+     *
      * @return the row ID of the newly inserted row
      * OR the primary key of the existing row if the input param 'conflictAlgorithm' =
      * {@link #CONFLICT_IGNORE}
      * OR -1 if any error
+     *
+     * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public long insertWithOnConflict(String table, String nullColumnHack,
                                      ContentValues initialValues, int conflictAlgorithm) {
@@ -1762,9 +1857,13 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @param table the table to delete from
      * @param whereClause the optional WHERE clause to apply when deleting.
      *            Passing null will delete all rows.
+     *
      * @return the number of rows affected if a whereClause is passed in, 0
      *         otherwise. To remove all rows and get a count pass "1" as the
      *         whereClause.
+     *
+     * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public int delete(String table, String whereClause, String[] whereArgs) {
         lock();
@@ -1803,7 +1902,11 @@ public class SQLiteDatabase extends SQLiteClosable {
      *            valid value that will be translated to NULL.
      * @param whereClause the optional WHERE clause to apply when updating.
      *            Passing null will update all rows.
+     *
      * @return the number of rows affected
+     *
+     * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public int update(String table, ContentValues values, String whereClause, String[] whereArgs) {
         return updateWithOnConflict(table, values, whereClause, whereArgs, CONFLICT_NONE);
@@ -1818,7 +1921,11 @@ public class SQLiteDatabase extends SQLiteClosable {
      * @param whereClause the optional WHERE clause to apply when updating.
      *            Passing null will update all rows.
      * @param conflictAlgorithm for update conflict resolver
+     *
      * @return the number of rows affected
+     *
+     * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public int updateWithOnConflict(String table, ContentValues values,
                                     String whereClause, String[] whereArgs, int conflictAlgorithm) {
@@ -1903,6 +2010,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * supported. it takes a write lock
      *
      * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public void execSQL(String sql) throws SQLException {
         long timeStart = SystemClock.uptimeMillis();
@@ -1963,7 +2071,9 @@ public class SQLiteDatabase extends SQLiteClosable {
      *
      * @param sql
      * @param bindArgs only byte[], String, Long and Double are supported in bindArgs.
+     *
      * @throws SQLException If the SQL string is invalid for some reason
+     * @throws IllegalStateException if the database is not open
      */
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
         if (bindArgs == null) {
@@ -2006,17 +2116,40 @@ public class SQLiteDatabase extends SQLiteClosable {
         }
     }
 
+    /**
+     * Public constructor which attempts to open the database. See {@link #create} and {@link #openDatabase}.
+     *
+     * <p>Sets the locale of the database to the system's current locale.
+     * Call {@link #setLocale} if you would like something else.</p>
+     *
+     * @param path The full path to the database
+     * @param password to use to open and/or create a database file (char array)
+     * @param factory The factory to use when creating cursors, may be NULL.
+     * @param flags 0 or {@link #NO_LOCALIZED_COLLATORS}.  If the database file already
+     *              exists, mFlags will be updated appropriately.
+     *
+     * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
+     */
     public SQLiteDatabase(String path, char[] password, CursorFactory factory, int flags) {
         this(path, password, factory, flags, null);
     }
 
     /**
-     * Private constructor. See {@link #create} and {@link #openDatabase}.
+     * Public constructor which attempts to open the database. See {@link #create} and {@link #openDatabase}.
+     *
+     * <p>Sets the locale of the database to the system's current locale.
+     * Call {@link #setLocale} if you would like something else.</p>
      *
      * @param path The full path to the database
+     * @param password to use to open and/or create a database file (char array)
      * @param factory The factory to use when creating cursors, may be NULL.
      * @param flags 0 or {@link #NO_LOCALIZED_COLLATORS}.  If the database file already
      *              exists, mFlags will be updated appropriately.
+     * @param databaseHook to run on pre/post key events
+     *
+     * @throws SQLiteException if the database cannot be opened
+     * @throws IllegalArgumentException if the database path is null
      */
     public SQLiteDatabase(String path, char[] password, CursorFactory factory, int flags, SQLiteDatabaseHook databaseHook) {
 
@@ -2172,6 +2305,7 @@ public class SQLiteDatabase extends SQLiteClosable {
     /**
      * Sets the locale for this database.  Does nothing if this database has
      * the NO_LOCALIZED_COLLATORS flag set or was opened read only.
+     *
      * @throws SQLException if the locale could not be set.  The most common reason
      * for this is that there is no collator available for the locale you requested.
      * In this case the database remains unchanged.
@@ -2481,6 +2615,7 @@ public class SQLiteDatabase extends SQLiteClosable {
      * when calling this method.
      *
      * @param sql The raw SQL string
+     *
      * @throws SQLException
      */
     /* package */ native void native_execSQL(String sql) throws SQLException;
@@ -2488,6 +2623,7 @@ public class SQLiteDatabase extends SQLiteClosable {
     /**
      * Native call to set the locale.  {@link #lock} must be held when calling
      * this method.
+     *
      * @throws SQLException
      */
     /* package */ native void native_setLocale(String loc, int flags);


### PR DESCRIPTION
## Fixed small memory leak

There is a very small memory leak in the code that was inherited from the Android project as reported here: https://code.google.com/p/android/issues/detail?id=22794

The Android project already fixed this leak when making some other changes in November 2011, in this commit: https://github.com/android/platform_frameworks_base/commit/e5360fbf3efe85427f7e7f59afe7bbeddb4949ac

The first commit in this PR fixes the memory leak by replacing `SQLiteDatabase.ActiveDatabases` with `private static WeakHashMap<SQLiteDatabase, Object> sActiveDatabases` and cleaning it up in `SQLiteDatabase.onAllReferencesReleased()`.

Note that in the Android project the reference is _not_ cleaned up in case the `SQLiteDatabase` instance is finalized, while no such distinction is made in my commit. I suspect their reasoning was that it would not be worth while to cleanup a weak reference to a `SQLiteDatabase` instance that is known to be going away.

## Mark some more exceptions in SQLiteDatabase class

I marked some more exceptions that may be thrown, as discussed in #176. I also added some Javadoc comments to public functions where missing.

## Small fix to public SQLiteDatabase.yieldIfContended functions

I added a small fix to `SQLiteDatabase.yieldIfContended()`, `SQLiteDatabase.yieldIfContendedSafely()`, and `SQLiteDatabase.yieldIfContendedSafely(long)` to simply return `false` if the database is closed.

## Testing

I tested the changes in a version of the test suite that repeats 9 times, as described in sqlcipher/sqlcipher-android-tests#8.