### PR TITLE
Remove the superfluous ProGuard rule for the database package

### DIFF
--- a/proguard-project.txt
+++ b/proguard-project.txt
@@ -53,6 +53,6 @@
     public static <fields>;
 }
 
--keep public class net.sqlcipher.** {
+-keep class net.sqlcipher.** {
     *;
 }

--- a/proguard-project.txt
+++ b/proguard-project.txt
@@ -56,7 +56,3 @@
 -keep public class net.sqlcipher.** {
     *;
 }
-
--keep public class net.sqlcipher.database.** {
-    *;
-}


### PR DESCRIPTION
"net.sqlcipher.**" already matches all classes in "net.sqlcipher" and in
its subpackages, see

http://proguard.sourceforge.net/manual/usage.html#classspecification