### PR TITLE
build an AAR and .pom file for Maven repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ gen/
 external/openssl
 external/sqlcipher
 libs/
+
+# AAR cruft
+R.txt
+sqlcipher-*.aar
+sqlcipher-*.pom

--- a/custom_rules.xml
+++ b/custom_rules.xml
@@ -5,10 +5,29 @@
     <isset property="env.ANDROID_NDK" />
   </condition>
 
+  <target name="-pre-clean">
+    <delete>
+      <fileset dir=".">
+        <include name="sqlcipher*-*.aar" />
+        <include name="sqlcipher*-*.pom" />
+      </fileset>
+    </delete>
+  </target>
+
   <target name="-getgitdetails" >
     <exec executable="git" outputproperty="git.describe">
       <arg value="describe"/>
     </exec>
+    <echo message="${git.describe}" file=".version"/>
+    <loadfile property="git.tag.version" srcFile=".version">
+        <filterchain>
+            <tokenfilter>
+                <replaceregex pattern="v" replace=""/>
+            </tokenfilter>
+        </filterchain>
+    </loadfile>
+    <delete file=".version"/>
+    <echo message="Version: ${git.tag.version}"/>
     <exec executable="git" outputproperty="git.revision">
       <arg value="rev-parse"/>
       <arg value="HEAD"/>
@@ -31,7 +50,7 @@
         <attribute name="Implementation-Vendor" value="Zetetic"/>
         <attribute name="Implementation-Title" value="SQLCipher for Android"/>
         <attribute name="Implementation-URL" value="https://www.zetetic.net/sqlcipher/open-source"/>
-        <attribute name="Implementation-Version" value="${git.describe}"/>
+        <attribute name="Implementation-Version" value="${git.tag.version}"/>
         <attribute name="Git-Revision" value="${git.revision}"/>
       </manifest>
     </jar>
@@ -40,6 +59,19 @@
   <target name="-post-build" depends="-getgitdetails,-javadoc">
     <property name="jar.dir" value="libs" />
     <property name="jar.name" value="${jar.dir}/sqlcipher.jar" />
+    <condition property="build.is.debug" value="true" else="false">
+      <equals arg1="${build.target}" arg2="debug" />
+    </condition>
+    <if condition="${build.is.debug}">
+      <then>
+        <property name="aar.name" value="sqlcipher-${git.tag.version}-debug.aar" />
+        <property name="pom.name" value="sqlcipher-${git.tag.version}-debug.pom" />
+      </then>
+      <else>
+        <property name="aar.name" value="sqlcipher-${git.tag.version}.aar" />
+        <property name="pom.name" value="sqlcipher-${git.tag.version}.pom" />
+      </else>
+    </if>
     <property file="${sdk.dir}/tools/source.properties" />
     <exec executable="cat" outputproperty="ndk.release">
       <arg value="${ndk.dir}/RELEASE.TXT"/>
@@ -53,7 +85,7 @@
         <attribute name="Implementation-Vendor" value="Zetetic"/>
         <attribute name="Implementation-Title" value="SQLCipher for Android"/>
         <attribute name="Implementation-URL" value="https://www.zetetic.net/sqlcipher/open-source"/>
-        <attribute name="Implementation-Version" value="${git.describe}"/>
+        <attribute name="Implementation-Version" value="${git.tag.version}"/>
         <attribute name="Git-Revision" value="${git.revision}"/>
         <attribute name="Android-SDK-Release" value="${Pkg.Revision}"/>
         <attribute name="Android-SDK-Host-OS" value="${Archive.HostOs}"/>
@@ -61,6 +93,40 @@
       </manifest>
     </jar>
     <copy file="${out.dir}/sqlcipher-javadoc.jar" todir="${jar.dir}" preservelastmodified="true" overwrite="true"/>
+    <replaceregexp file="AndroidManifest.xml"
+                   match="versionName=&quot;.*&quot;"
+                   replace="versionName=&quot;${git.tag.version}&quot;"
+                   flags="m"/>
+    <replaceregexp file="AndroidManifest.xml"
+                   match="&lt;application.*/application&gt;"
+                   replace=""
+                   flags="s"/>
+    <!-- AARs require R.txt and res/ even if they are empty -->
+    <delete file="R.txt"/>
+    <touch file="R.txt"/>
+    <!-- reset timestamp for reproducibility -->
+    <touch>
+      <fileset file="AndroidManifest.xml"/>
+      <fileset dir="res"/>
+      <fileset dir="assets"/>
+      <fileset dir="libs"/>
+    </touch>
+    <!-- AAR that includes the SQLCipher shared libraries -->
+    <zip destfile="${aar.name}" level="9">
+      <zipfileset dir="." includes="AndroidManifest.xml"/>
+      <zipfileset dir="." includes="${jar.name}" fullpath="classes.jar"/>
+      <zipfileset dir="." includes="R.txt"/>
+      <zipfileset dir="res" excludes="**/*.*" prefix="res"/>
+      <zipfileset dir="assets" prefix="assets"/>
+      <zipfileset dir="libs" includes="**/*.so" prefix="jni"/>
+    </zip>
+    <delete file="R.txt"/>
+    <!-- generate .pom for maven repos -->
+    <copy file="sqlcipher.pom" tofile="${pom.name}" overwrite="true" force="true"/>
+    <replaceregexp file="${pom.name}"
+                   match="VERSION"
+                   replace="${git.tag.version}"
+                   flags="m"/>
   </target>
 
 </project>

--- a/custom_rules.xml
+++ b/custom_rules.xml
@@ -20,6 +20,7 @@
     <javadoc sourcepath="${source.dir}"
              destdir="${out.dir}/javadoc"
              packagenames="net.sqlcipher.*"
+             additionalparam="-notimestamp"
              windowtitle="SQLCipher for Android"
              doctitle="SQLCipher for Android" />
     <delete file="${javadoc.jar.name}"/>

--- a/sqlcipher.pom
+++ b/sqlcipher.pom
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>net.sqlcipher</groupId>
+  <artifactId>sqlcipher</artifactId>
+  <version>VERSION</version>
+  <packaging>aar</packaging>
+  <name>SQLCipher</name>
+  <url>https://www.zetetic.net/sqlcipher</url>
+  <description></description>
+  <licenses>
+   <license>
+     <name>Apache-2.0</name>
+     <url>https://github.com/sqlcipher/android-database-sqlcipher/blob/master/LICENSE</url>
+   </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>zetetic</id>
+      <name>Zetetic</name>
+      <email>support@zetetic.net</email>
+    </developer>
+    <developer>
+      <id>guardianproject</id>
+      <name>Guardian Project</name>
+      <email>support@guardianproject.info</email>
+    </developer>
+  </developers>
+  <issueManagement>
+    <url>https://github.com/sqlcipher/android-database-sqlcipher/issues</url>
+    <system>GitHub</system>
+  </issueManagement>
+  <scm>
+    <connection>scm:https://github.com/sqlcipher/android-database-sqlcipher.git</connection>
+    <developerConnection>scm:git@github.com:sqlcipher/android-database-sqlcipher.git</developerConnection>
+    <url>scm:https://github.com/sqlcipher/android-database-sqlcipher</url>
+  </scm>
+</project>


### PR DESCRIPTION
AAR libraries are the standard for Android these days when making libraries that include anything in addition to Java classes.  This adds AAR and .pom generation to the standard build system.  The .pom file is needed for Maven repos like MavenCentral and jCenter, which are the default library repos for gradle for Android.

The products of this can then just be uploaded to jCenter/MavenCentral with GPG .asc signatures on both the .aar and .pom files.  I can handle the uploading to jCenter if you're OK with it being managed under the Guardian Project group.