### PR TITLE
exposing setExtras for compatibility with android v.23 (6.0.0)

### DIFF
--- a/src/net/sqlcipher/AbstractCursor.java
+++ b/src/net/sqlcipher/AbstractCursor.java
@@ -506,6 +506,10 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
         return Bundle.EMPTY;
     }
 
+    @Override
+    public void setExtras(Bundle extras) {
+    }
+
     public Bundle respond(Bundle extras) {
         return Bundle.EMPTY;
     }


### PR DESCRIPTION
Right now it's impossible to build sqlcipher for android v.23 because of the exposed "setExtras" method. this patch fixes it.