### PR TITLE
Fix Android N preview build on API 23

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-23

--- a/src/net/sqlcipher/AbstractCursor.java
+++ b/src/net/sqlcipher/AbstractCursor.java
@@ -511,6 +511,15 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
     }
 
     /**
+     * Bogus implementation needed to build with Android 6.0(+) SDK.
+     * This implementation will throw a RuntimeException with a
+     * "not implemented" message.
+     */
+    public void setExtras(Bundle ignored) {
+        throw new RuntimeException("void setExtras(Bundle) not implemented");
+    }
+
+    /**
      * This function returns true if the field has been updated and is
      * used in conjunction with {@link #getUpdatedField} to allow subclasses to
      * support reading uncommitted updates. NOTE: This function and


### PR DESCRIPTION
While I completely understand the desire to support *execution* on older Android versions, I find it strange that we cannot *build* this project on the new Android SDK as discussed in: https://discuss.zetetic.net/t/android-build-faile/1319

The only fix needed to build on SDK 23 is to define a bogus AbstractCursor.setExtras(Bundle) method.

An alternative would be to implement a working setExtras(Bundle) method for the AbstractCursor/AbstractWindowedCursor subclass(es).