### PR TITLE
Fix Android N preview for API 23 (build)

### DIFF
--- a/src/net/sqlcipher/AbstractCursor.java
+++ b/src/net/sqlcipher/AbstractCursor.java
@@ -42,6 +42,8 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
     DataSetObservable mDataSetObservable = new DataSetObservable();
     ContentObservable mContentObservable = new ContentObservable();
 
+    private Bundle mExtras = Bundle.EMPTY;
+
     /* -------------------------------------------------------- */
     /* These need to be implemented by subclasses */
     abstract public int getCount();
@@ -502,8 +504,12 @@ public abstract class AbstractCursor implements android.database.CrossProcessCur
         return false;
     }
 
+    public void setExtras(Bundle extras) {
+        mExtras = (extras == null) ? Bundle.EMPTY : extras;
+    }
+
     public Bundle getExtras() {
-        return Bundle.EMPTY;
+        return mExtras;
     }
 
     public Bundle respond(Bundle extras) {


### PR DESCRIPTION
This change properly supports AbstractCursor.setExtras/AbstractCursor.getExtras according to API 23 and was taken from the AOSP (with the "@Override" attribute omitted). It would allow people to build on API 23.

In addition to fixing the build on API 23, this change fixes a remote possibility that someone passes a SQLiteCursor, MatrixCursor, or BulkCursorToCursorAdaptor to an external library function that takes a Cursor and calls setExtras on that Cursor. While I expect the changes of this happening to be very low, it is a side effect of a build problem that can easily be fixed by the change proposed here.

Thanks in advance for your consideration.