### PR TITLE
Using SecureRandom instead of Random

### DIFF
--- a/src/net/sqlcipher/database/SQLiteDatabase.java
+++ b/src/net/sqlcipher/database/SQLiteDatabase.java
@@ -40,7 +40,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -368,7 +368,7 @@ public class SQLiteDatabase extends SQLiteClosable {
     private static int sQueryLogTimeInMillis = 0;  // lazily initialized
     private static final int QUERY_LOG_SQL_LENGTH = 64;
     private static final String COMMIT_SQL = "COMMIT;";
-    private final Random mRandom = new Random();
+    private final SecureRandom mRandom = new SecureRandom();
     private String mLastSqlStatement = null;
 
     // String prefix for slow database query EventLog records that show


### PR DESCRIPTION
Random class should never be used, because of security issues:

From http://docs.oracle.com/javase/6/docs/api/java/util/Random.html:

"An instance of this class is used to generate a stream of pseudorandom numbers. The class uses a 48-bit seed, which is modified using a linear congruential formula. (See Donald Knuth, The Art of Computer Programming, Volume 3, Section 3.2.1.)"

More info:

https://static.aminer.org/pdf/PDF/000/211/835/secret_linear_congruential_generators_are_not_cryptographically_secure.pdf