### PR TITLE
Address a crash when close is called from finalize.

### DIFF
--- a/src/net/sqlcipher/database/SQLiteProgram.java
+++ b/src/net/sqlcipher/database/SQLiteProgram.java
@@ -58,6 +58,11 @@ public abstract class SQLiteProgram extends SQLiteClosable {
     @Deprecated
     protected long nStatement = 0;
 
+    /**
+     * Indicates whether {@link #close()} has been called.
+     */
+    boolean mClosed = false;
+
     /* package */ SQLiteProgram(SQLiteDatabase db, String sql) {
         mDatabase = db;
         mSql = sql.trim();
@@ -142,7 +147,7 @@ public abstract class SQLiteProgram extends SQLiteClosable {
                 // it is in compiled-sql cache. reset its CompiledSql#mInUse flag
                 mCompiledSql.release();
             }
-        } 
+        }
     }
 
     /**
@@ -177,6 +182,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
      * @param index The 1-based index to the parameter to bind null to
      */
     public void bindNull(int index) {
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
+        }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
         }
@@ -196,6 +204,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
      * @param value The value to bind
      */
     public void bindLong(int index, long value) {
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
+        }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
         }
@@ -215,6 +226,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
      * @param value The value to bind
      */
     public void bindDouble(int index, double value) {
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
+        }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
         }
@@ -236,6 +250,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
     public void bindString(int index, String value) {
         if (value == null) {
             throw new IllegalArgumentException("the bind value at index " + index + " is null");
+        }
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
         }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
@@ -259,6 +276,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
         if (value == null) {
             throw new IllegalArgumentException("the bind value at index " + index + " is null");
         }
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
+        }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
         }
@@ -274,6 +294,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
      * Clears all existing bindings. Unset bindings are treated as NULL.
      */
     public void clearBindings() {
+        if (mClosed) {
+            throw new IllegalStateException("program already closed");
+        }
         if (!mDatabase.isOpen()) {
             throw new IllegalStateException("database " + mDatabase.getPath() + " already closed");
         }
@@ -289,6 +312,9 @@ public abstract class SQLiteProgram extends SQLiteClosable {
      * Release this program's resources, making it invalid.
      */
     public void close() {
+        if (mClosed) {
+            return;
+        }
         if (!mDatabase.isOpen()) {
             return;
         }
@@ -298,6 +324,7 @@ public abstract class SQLiteProgram extends SQLiteClosable {
         } finally {
             mDatabase.unlock();
         }
+        mClosed = true;
     }
 
     /**

--- a/src/net/sqlcipher/database/SQLiteQuery.java
+++ b/src/net/sqlcipher/database/SQLiteQuery.java
@@ -32,18 +32,16 @@ public class SQLiteQuery extends SQLiteProgram {
 
     /** The index of the unbound OFFSET parameter */
     private int mOffsetIndex;
-    
+
     /** Args to bind on requery */
     private String[] mBindArgs;
 
-    private boolean mClosed = false;
-
     /**
      * Create a persistent query object.
-     * 
+     *
      * @param db The database that this query object is associated with
-     * @param query The SQL string for this query. 
-     * @param offsetIndex The 1-based index to the OFFSET parameter, 
+     * @param query The SQL string for this query.
+     * @param offsetIndex The 1-based index to the OFFSET parameter,
      */
     /* package */ SQLiteQuery(SQLiteDatabase db, String query, int offsetIndex, String[] bindArgs) {
         super(db, query);
@@ -96,7 +94,7 @@ public class SQLiteQuery extends SQLiteProgram {
      * Get the column count for the statement. Only valid on query based
      * statements. The database must be locked
      * when calling this method.
-     * 
+     *
      * @return The number of column in the statement's result set.
      */
     /* package */ int columnCountLocked() {
@@ -111,7 +109,7 @@ public class SQLiteQuery extends SQLiteProgram {
     /**
      * Retrieves the column name for the given column index. The database must be locked
      * when calling this method.
-     * 
+     *
      * @param columnIndex the index of the column to get the name for
      * @return The requested column's name
      */
@@ -123,16 +121,10 @@ public class SQLiteQuery extends SQLiteProgram {
             releaseReference();
         }
     }
-    
+
     @Override
     public String toString() {
         return "SQLiteQuery: " + mSql;
-    }
-    
-    @Override
-    public void close() {
-        super.close();
-        mClosed = true;
     }
 
     /**
@@ -154,7 +146,7 @@ public class SQLiteQuery extends SQLiteProgram {
                 errMsg.append(" ");
                 IllegalStateException leakProgram = new IllegalStateException(
                         errMsg.toString(), e);
-                throw leakProgram;                
+                throw leakProgram;
             }
         }
     }
@@ -183,7 +175,7 @@ public class SQLiteQuery extends SQLiteProgram {
         if (!mClosed) super.bindString(index, value);
     }
 
-    private final native int native_fill_window(CursorWindow window, 
+    private final native int native_fill_window(CursorWindow window,
             int startPos, int offsetParam, int maxRead, int lastPos);
 
     private final native int native_column_count();


### PR DESCRIPTION
On Android, finalize has 10 seconds to complete. SQLiteProgram.close is being called from finalize, and it does not consider whether it has already been closed before it tries to acquire the database lock. If the database is in use elsewhere, this can easily cause finalize to timeout, causing a fatal exception. This fixes the issue by making a second call to close a no-op.