### PR TITLE
Limit memory usage, improve cursor read throughput.

### DIFF
--- a/android-database-sqlcipher/src/main/cpp/CursorWindow.h
+++ b/android-database-sqlcipher/src/main/cpp/CursorWindow.h
@@ -31,16 +31,13 @@
 
 #define DEFAULT_WINDOW_SIZE 4096
 #define MAX_WINDOW_SIZE (1024 * 1024)
-#define WINDOW_ALLOCATION_SIZE 4096
+#define WINDOW_ALLOCATION_SIZE (MAX_WINDOW_SIZE / 8)
 
-#define ROW_SLOT_CHUNK_NUM_ROWS 16
-
-#define GROW_WINDOW_SIZE_EXTRA MAX_WINDOW_SIZE / 10
+#define ROW_SLOT_CHUNK_NUM_ROWS 256
 
 // Row slots are allocated in chunks of ROW_SLOT_CHUNK_NUM_ROWS,
 // with an offset after the rows that points to the next chunk
 #define ROW_SLOT_CHUNK_SIZE ((ROW_SLOT_CHUNK_NUM_ROWS * sizeof(row_slot_t)) + sizeof(uint32_t))
-
 
 #if LOG_NDEBUG
 


### PR DESCRIPTION
We've been experiencing the following two problems: 

1. OOM's on queries with large result sets.
2. Very poor performance on queries with large result sets (27 seconds to read 18,500 rows on a OnePlus One).

These problems are (in part) a result of the following:

(1) SQLCipher will expand the CursorWindow to fit the entire query, with no upper bound on memory usage. This opens up the possibility of OOM's, as well as increases the initial loading time of a Cursor.

The cursor will take longer to load because filling the CursorWindow will take longer. For instance, internally, a cursor has to call getCount() before anything else. getCount() will fill the entire window while determining the count. If the query can't fit in the window, then it'll just fill the window as much as it can, then go on counting the rest of the query without bothering to store it. But when the window expands indefinitely, that means every single row is stored in the window. This can take a long time on large result sets. You can't read anything from the cursor until this operation has completed.

(2) Other inefficiencies around filling the cursor window -- notably, the size of the allocations for ROW_CHUNKS.

This PR addresses those issues by making two changes:

(1) I copied over the relevant parts of the original implementation of CursorWindow.cpp#alloc(). This implementation will respect the max window size. It'll return 0 if it has to allocate too much memory. All of the other historical Android platform code that is in use elsewhere already recognizes that this is a possibility and accounts for it. 

That does mean that the system will have to requery if the user requests to jump to position that is not present in the window, but I've tested it (by setting a low MAX_WINDOW_SIZE) and it works as expected. True, this requery will take place on the main thread and cause hiccups, but given the MAX_WINDOW_SIZE of 1MB, you'll only run into this for large result sets. And given that not doing this will hurt initial loading performance on large result sets, it's probably better to just take the hit on requerying (the Android codebase continues to take this approach to this day).

(2) Increased ROW_SLOW_CHUNK_NUM_ROWS to 256. I can't say why this has as big an impact as it does (it was just one of the many knobs I was turning), but this has a huge effect -- an even bigger impact than setting the max window size! 

Now, this will increase the baseline memory usage queries. Specifically, this number determines ROW_SLOT_CHUNK_SIZE, which is defined as:

```C++
ROW_SLOT_CHUNK_SIZE ((ROW_SLOT_CHUNK_NUM_ROWS * sizeof(row_slot_t)) + sizeof(uint32_t))
```

row_slot_t is just a struct that wraps another uint32_t, so you can see that the memory footprint here is still small, even after we bump it from 16 to 256. Why 256? Higher values seemed to have diminishing returns across my various test devices.

After these changes, performing a query that returned 18,500 rows on a OnePlus One went from 27 seconds to ~2 seconds.