### PR TITLE
don't use repo openSSL code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.tar.gz
+*.tar.gz.*
 .gradle
 build
 .DS_Store

--- a/android-database-sqlcipher/build-openssl-libraries.sh
+++ b/android-database-sqlcipher/build-openssl-libraries.sh
@@ -2,13 +2,15 @@
 
 MINIMUM_ANDROID_SDK_VERSION=$1
 MINIMUM_ANDROID_64_BIT_SDK_VERSION=$2
-OPENSSL=openssl-$3
+OPENSSL=OpenSSL_$3
 
 (cd src/main/external/;
+ wget https://github.com/openssl/openssl/archive/${OPENSSL}.tar.gz
  gunzip -c ${OPENSSL}.tar.gz | tar xf -
 )
 
-(cd src/main/external/${OPENSSL};
+pwd
+(cd src/main/external/openssl-${OPENSSL};
 
  if [ ! ${MINIMUM_ANDROID_SDK_VERSION} ]; then
      echo "MINIMUM_ANDROID_SDK_VERSION was not provided, include and rerun"

--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ ext {
   nativeRootOutputDir = "${projectDir}/${mainProjectName}/src/main"
   androidNativeRootDir = "${nativeRootOutputDir}/external/android-libs"
   sqlcipherDir = "${projectDir}/${mainProjectName}/src/main/external/sqlcipher"
-  opensslVersion = "1.1.1b"
-  opensslDir = "${projectDir}/${mainProjectName}/src/main/external/openssl-${opensslVersion}"
+  opensslVersion = "1_1_1b"
+  opensslDir = "${projectDir}/${mainProjectName}/src/main/external/openssl-OpenSSL_${opensslVersion}"
   if(project.hasProperty('debugBuild') && debugBuild.toBoolean()) {
     otherSqlcipherCFlags = ""
     ndkBuildType="NDK_DEBUG=1"


### PR DESCRIPTION
This repo is **huge** !

One reason is the praxis to check-in archives from openSSL. With this PR, it will be downloaded if needed and no more check-in is necessary  