### PR TITLE
follow advice by Nick Parker

### DIFF
--- a/android-database-sqlcipher/src/main/cpp/net_sqlcipher_CursorWindow.cpp
+++ b/android-database-sqlcipher/src/main/cpp/net_sqlcipher_CursorWindow.cpp
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace sqlcipher {


### PR DESCRIPTION
@developernotes I followed your advice
```
export ANDROID_NDK_ROOT=~/Development/android-ndk-r15c/
make distclean
make build-debug
```

and run into this 

> threads_pthread.c:(.text+0x18): undefined reference to `pthread_atfork'
<img width="1220" alt="image" src="https://user-images.githubusercontent.com/3314607/59548473-2d334080-8f50-11e9-92ef-ae0913044f73.png">


