### PR TITLE
ignore 'not an error' exceptions

### DIFF
--- a/android-database-sqlcipher/src/main/java/net/sqlcipher/database/SQLiteDatabase.java
+++ b/android-database-sqlcipher/src/main/java/net/sqlcipher/database/SQLiteDatabase.java
@@ -2598,7 +2598,7 @@ public class SQLiteDatabase extends SQLiteClosable {
                     rekey(password);
                 }
                 shouldCloseConnection = false;
-            } else {
+            } else if (!ex.getMessage().contains("not an error")) {
                 throw ex;
             }
             if(keyMaterial != null && keyMaterial.length > 0) {


### PR DESCRIPTION
In https://fabric.io/ I see a lot of them
![image](https://user-images.githubusercontent.com/3314607/59904044-d079cf00-9402-11e9-8f99-c80f09f23cfd.png)

Because I want to reduce errors there, I want to get rid of it.

And as it looks like (I didn't debug in C code) you throw an error with that text, am I right ?

![image](https://user-images.githubusercontent.com/3314607/59904238-5138cb00-9403-11e9-9ce2-b88ebe1d5b8c.png)

