### PR TITLE
(only a question) use most recent NDK

### DIFF
--- a/android-database-sqlcipher/build-openssl-libraries.sh
+++ b/android-database-sqlcipher/build-openssl-libraries.sh
@@ -3,6 +3,7 @@
 MINIMUM_ANDROID_SDK_VERSION=$1
 MINIMUM_ANDROID_64_BIT_SDK_VERSION=$2
 OPENSSL=openssl-$3
+ANDROID_NDK_ROOT=$ANDROID_HOME/ndk-bundle
 
 (cd src/main/external/;
  gunzip -c ${OPENSSL}.tar.gz | tar xf -
@@ -57,19 +58,10 @@ OPENSSL=openssl-$3
 
  rm -rf ${ANDROID_LIB_ROOT}
  
- for SQLCIPHER_TARGET_PLATFORM in armeabi armeabi-v7a x86 x86_64 arm64-v8a
+ for SQLCIPHER_TARGET_PLATFORM in armeabi-v7a x86 x86_64 arm64-v8a
  do
      echo "Building libcrypto.a for ${SQLCIPHER_TARGET_PLATFORM}"
      case "${SQLCIPHER_TARGET_PLATFORM}" in
-         armeabi)
-             TOOLCHAIN_ARCH=arm
-             TOOLCHAIN_PREFIX=arm-linux-androideabi
-             TOOLCHAIN_FOLDER=arm-linux-androideabi
-             CONFIGURE_ARCH=android-arm
-             ANDROID_API_VERSION=${MINIMUM_ANDROID_SDK_VERSION}
-             OFFSET_BITS=32
-             TOOLCHAIN_DIR=${ANDROID_TOOLCHAIN_DIR}-armeabi
-             ;;
          armeabi-v7a)
              TOOLCHAIN_ARCH=arm
              TOOLCHAIN_PREFIX=arm-linux-androideabi
@@ -116,8 +108,7 @@ OPENSSL=openssl-$3
      python ${ANDROID_NDK_ROOT}/build/tools/make_standalone_toolchain.py \
             --arch ${TOOLCHAIN_ARCH} \
             --api ${ANDROID_API_VERSION} \
-            --install-dir ${TOOLCHAIN_DIR} \
-            --unified-headers
+            --install-dir ${TOOLCHAIN_DIR}
 
      if [ $? -ne 0 ]; then
          echo "Error executing make_standalone_toolchain.py for ${TOOLCHAIN_ARCH}"

--- a/android-database-sqlcipher/src/main/cpp/Application32.mk
+++ b/android-database-sqlcipher/src/main/cpp/Application32.mk
@@ -1,5 +1,5 @@
 APP_PROJECT_PATH := $(shell pwd)
-APP_ABI := armeabi armeabi-v7a x86
+APP_ABI := armeabi-v7a x86
 APP_PLATFORM := android-$(NDK_APP_PLATFORM)
 APP_BUILD_SCRIPT := $(APP_PROJECT_PATH)/Android.mk
 APP_STL := stlport_static

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ ext {
   mavenDeveloperEmail = "support@zetetic.net"
   mavenDeveloperOrganization = "Zetetic LLC"
   mavenDeveloperUrl = "https://www.zetetic.net"
-  minimumAndroidSdkVersion = 14
+  minimumAndroidSdkVersion = 16
   minimumAndroid64BitSdkVersion = 21
   targetAndroidSdkVersion = 26
   compileAndroidSdkVersion = 26


### PR DESCRIPTION
This repo is frozen to NDK 15, this makes it not ready prepared for the future. Midterm you will run probably into deprecation issues. 

So I want to see if I can make it work to use most recent NDK, to get rid of download NDK 15 for build.
But I run into this

![image](https://user-images.githubusercontent.com/3314607/59943157-cf2bbf00-9461-11e9-830a-2c4691353f20.png)

But I'm out of ideas how to solve this.

Do you have an idea how to solve this ?