### PR TITLE
cleanup: remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The latest AAR binary package information can be [here](https://www.zetetic.net/
 ### Compatibility
 
 SQLCipher for Android runs on Android 4.1–Android 10, for `armeabi-v7a`, `x86`, `x86_64`, and `arm64_v8a` architectures.
-    
+
 ### Contributions
 
 We welcome contributions, to contribute to SQLCipher for Android, a [contributor agreement](https://www.zetetic.net/contributions/) needs to be submitted. All submissions should be based on the `master` branch.
@@ -44,7 +44,7 @@ Error: file is encrypted or is not a database
 
 ### Application Integration
 
-You have a two main options for using SQLCipher for Android in your app: 
+You have a two main options for using SQLCipher for Android in your app:
 
 - Using it with Room or other consumers of the `androidx.sqlite` API
 

--- a/SQLCIPHER_LICENSE
+++ b/SQLCIPHER_LICENSE
@@ -2,7 +2,7 @@ http://sqlcipher.net
 
  Copyright (c) 2010 Zetetic LLC
             All rights reserved.
-            
+
             Redistribution and use in source and binary forms, with or without
             modification, are permitted provided that the following conditions are met:
                 * Redistributions of source code must retain the above copyright
@@ -13,7 +13,7 @@ http://sqlcipher.net
                 * Neither the name of the ZETETIC LLC nor the
                   names of its contributors may be used to endorse or promote products
                   derived from this software without specific prior written permission.
-            
+
             THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
             EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
             WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/android-database-sqlcipher/build-openssl-libraries.sh
+++ b/android-database-sqlcipher/build-openssl-libraries.sh
@@ -55,7 +55,7 @@ OPENSSL=openssl-$3
  no-srtp"
 
  rm -rf ${ANDROID_LIB_ROOT}
- 
+
  for SQLCIPHER_TARGET_PLATFORM in armeabi-v7a x86 x86_64 arm64-v8a
  do
      echo "Building libcrypto.a for ${SQLCIPHER_TARGET_PLATFORM}"
@@ -99,7 +99,7 @@ OPENSSL=openssl-$3
      make clean
      PATH=${TOOLCHAIN_BIN_PATH}:${PATH} \
          make build_libs
-     
+
      if [[ $? -ne 0 ]]; then
          echo "Error executing make for platform:${SQLCIPHER_TARGET_PLATFORM}"
          exit 1


### PR DESCRIPTION
Changes proposed in this pull request:

nit: remove trailing whitespace from:

- README.md
- SQLCIPHER_LICENSE
- android-database-sqlcipher/build-openssl-libraries.sh

I would be happy to split these up, if needed. I assume Zetetic should still have my contributor form, I would be happy to sign again if needed for any reason.