### PR TITLE
update androidx.sqlite/sqlite -> 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ closure:
 
 ```gradle
 implementation "net.zetetic:android-database-sqlcipher:4.5.3"
-implementation "androidx.sqlite:sqlite:2.0.1"
+implementation "androidx.sqlite:sqlite:2.1.0"
 ```
 
 (replacing `4.5.3` with the version you want)

--- a/android-database-sqlcipher/build.gradle
+++ b/android-database-sqlcipher/build.gradle
@@ -40,7 +40,7 @@ android {
     }
 
     dependencies {
-        implementation "androidx.sqlite:sqlite:2.0.1"
+        implementation "androidx.sqlite:sqlite:2.1.0"
     }
 
     editorconfig {


### PR DESCRIPTION
__UPDATED January 2023:__

I think it would be ideal to update this androidx.sqlite/sqlite to `2.2.0`, but it looks to me like this would incur a requirement for Android SDK 31. I am not sure if we are ready for this kind of breaking change yet.

This is just a suggestion to use the latest version of `androidx.sqlite` from <https://mvnrepository.com/artifact/androidx.sqlite/sqlite>. This worked for me when using my custom build in an Apache Cordova test project. I hope I will have a chance to test an AAR with the test suite in `sqlcipher-android-tests` in the near future, no promises due to some urgent project work. I am raising this as a draft PR for now.