### PR TITLE
remove outdated opensslVersion from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ ext {
   compileAndroidSdkVersion = 26
   mainProjectName = "android-database-sqlcipher"
   nativeRootOutputDir = "${projectDir}/${mainProjectName}/src/main"
-  opensslVersion = "1.1.1g"
   if(project.hasProperty('sqlcipherRoot')) {
     sqlcipherDir = "${sqlcipherRoot}"
   }


### PR DESCRIPTION
`git grep` shows the outdated `opensslVersion` used in only one place, looks safe to remove

(I am actually trying to build an updated version in my workarea, with Android NDK r23 which seems to be their latest LTS, as I make this PR)

While I don't anticipate this to break anything, I am raising this as a draft PR NOT TESTED until I get a chance to test this from start to finish. In case a maintainer feels confident to apply this proposal now WITH AN UPDATED TITLE, that would be awesome as well.

And thanks to @developernotes for updating `SQLCIPHER_ANDROID_VERSION` in the documentation.