### PR TITLE
DRAFT RFC docs: update recommended NDK -> r23c

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ For applications which utilize ProGuard, a few additional rules must be included
 
 ### Building
 
-In order to build `android-database-sqlcipher` from source you will need both the Android SDK, Gradle, Android NDK, SQLCipher core source directory, and an OpenSSL source directory. We currently recommend using Android NDK LTS version `23.0.7599858`.
+In order to build `android-database-sqlcipher` from source you will need both the Android SDK, Gradle, Android NDK, SQLCipher core source directory, and an OpenSSL source directory. We currently recommend using Android NDK version r23c (`23.2.8568313`).
 
 To complete the `make` command, the `ANDROID_NDK_HOME` environment variable must be defined which should point to your NDK root. Once you have cloned the repo, change directory into the root of the repository and run the following commands:
 


### PR DESCRIPTION
(no longer LTS)

ref:
- https://github.com/android/ndk/wiki/Changelog-r23#r23c
- https://github.com/android/ndk/wiki/Unsupported-Downloads

This proposal gets the latest SDK possible without dropping the existing Android 4.1 support.

I would *personally* favor dropping the super-old Jelly Bean support and recommending NDK r25 LTS version instead.