### PR TITLE
docs: only specify minimum Android version [Jelly Bean]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The latest AAR binary package information can be [here](https://www.zetetic.net/
 
 ### Compatibility
 
-SQLCipher for Android runs on Android 4.1–Android 13, for `armeabi-v7a`, `x86`, `x86_64`, and `arm64_v8a` architectures.
+SQLCipher for Android runs on Android from 4.1 (Jelly Bean), for `armeabi-v7a`, `x86`, `x86_64`, and `arm64_v8a` architectures.
 
 ### Contributions
 


### PR DESCRIPTION
One less thing to keep updating in the documentation