### PR TITLE
RFC: NDK r25 LTS updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ For applications which utilize ProGuard, a few additional rules must be included
 
 ### Building
 
-In order to build `android-database-sqlcipher` from source you will need both the Android SDK, Gradle, Android NDK, SQLCipher core source directory, and an OpenSSL source directory. We currently recommend using Android NDK LTS version `23.0.7599858`.
+In order to build `android-database-sqlcipher` from source you will need both the Android SDK, Gradle, Android NDK, SQLCipher core source directory, and an OpenSSL source directory. We currently recommend using Android NDK LTS version `25.1.8937393` (r25b).
 
 To complete the `make` command, the `ANDROID_NDK_HOME` environment variable must be defined which should point to your NDK root. Once you have cloned the repo, change directory into the root of the repository and run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The latest AAR binary package information can be [here](https://www.zetetic.net/
 
 ### Compatibility
 
-SQLCipher for Android runs on Android from 4.1 (Jelly Bean), for `armeabi-v7a`, `x86`, `x86_64`, and `arm64_v8a` architectures.
+SQLCipher for Android runs on Android from 4.4 (KitKat), for `armeabi-v7a`, `x86`, `x86_64`, and `arm64_v8a` architectures.
 
 ### Contributions
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ ext {
   mavenDeveloperEmail = "support@zetetic.net"
   mavenDeveloperOrganization = "Zetetic LLC"
   mavenDeveloperUrl = "https://www.zetetic.net"
-  minimumAndroidSdkVersion = 16
+  minimumAndroidSdkVersion = 19
   minimumAndroid64BitSdkVersion = 21
   targetAndroidSdkVersion = 26
   compileAndroidSdkVersion = 26


### PR DESCRIPTION
- drop Jelly Bean support - update minimum API to 19 (KitKat), as needed by NDK beyond outdated r23 ref:
  - https://github.com/android/ndk/wiki/Changelog-r24
- update recommended NDK to r25b ref:
  - https://developer.android.com/ndk/downloads
  - https://github.com/android/ndk/wiki/Changelog-r25

rationale:
- It looks like NDK pre-r25 is no longer supported
- Jelly Bean is now super-old, no longer supported beyond NDK r23, does not look worth supporting too much longer

supersedes other proposals:

- #609 - now included in this PR
- #608

✅ tested updated build together with androidx.sqlite/sqlite 2.1.0 (PR #501) in <https://github.com/sqlcipher/sqlcipher-android-tests/pull/44> ... looks like several tests need some more compiler flags

I need to build an updated version with some customizations for an organization and may even drop KitKat in my own fork, hoping to keep divergence to a minimum. Happy new year and thanks in advance for your consideration!