### PR TITLE
use mavenCentral() instead of deprecated jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven {
       url "https://plugins.gradle.org/m2/"
     }
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 


### PR DESCRIPTION
resolves a deprecation warning

ref:

- https://docs.gradle.org/7.6/userguide/upgrading_version_6.html#jcenter_deprecation